### PR TITLE
JVM-Packages: Adding support for detecting musl-based Linux

### DIFF
--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -32,6 +32,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <dependency>
             <groupId>com.typesafe.akka</groupId>
             <artifactId>akka-actor_${scala.binary.version}</artifactId>
             <version>2.5.23</version>

--- a/jvm-packages/xgboost4j/pom.xml
+++ b/jvm-packages/xgboost4j/pom.xml
@@ -35,6 +35,7 @@
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-lambda</artifactId>
             <version>1.2.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -115,7 +115,7 @@ class NativeLibLoader {
    *   <li>Supported OS: macOS, Windows, Linux, Solaris.</li>
    *   <li>Supported Architectures: x86_64, aarch64, sparc.</li>
    * </ul>
-   * Throws UnsatisfiedLinkError if the library failed to load it's dependencies.
+   * Throws UnsatisfiedLinkError if the library failed to load its dependencies.
    * @throws IOException If the library could not be extracted from the jar.
    */
   static synchronized void initXGBoost() throws IOException {

--- a/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
+++ b/jvm-packages/xgboost4j/src/main/java/ml/dmlc/xgboost4j/java/NativeLibLoader.java
@@ -45,7 +45,7 @@ class NativeLibLoader {
 
     final String name;
 
-    private OS(String name) {
+    OS(String name) {
       this.name = name;
     }
 
@@ -80,7 +80,7 @@ class NativeLibLoader {
 
     final String name;
 
-    private Arch(String name) {
+    Arch(String name) {
       this.name = name;
     }
 

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/ArchDetectionTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/ArchDetectionTest.java
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package ml.dmlc.xgboost4j.java;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Collection;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
+import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertSame;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.X86_64;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.AARCH64;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.SPARC;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.Arch.detectArch;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Test cases for {@link NativeLibLoader.Arch}.
+ */
+@RunWith(Enclosed.class)
+public class ArchDetectionTest {
+
+  private static final String OS_ARCH_PROPERTY = "os.arch";
+
+  @RunWith(Parameterized.class)
+  public static class ParameterizedArchDetectionTest {
+
+    private final String osArchValue;
+    private final NativeLibLoader.Arch expectedArch;
+
+    public ParameterizedArchDetectionTest(String osArchValue, NativeLibLoader.Arch expectedArch) {
+      this.osArchValue = osArchValue;
+      this.expectedArch = expectedArch;
+    }
+
+    @Parameters
+    public static Collection<Object[]> data() {
+      return asList(new Object[][]{
+        {"x86_64", X86_64},
+        {"amd64", X86_64},
+        {"aarch64", AARCH64},
+        {"arm64", AARCH64},
+        {"sparc64", SPARC}
+      });
+    }
+
+    @Test
+    public void testArch() throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(OS_ARCH_PROPERTY, osArchValue);
+        assertSame(detectArch(), expectedArch);
+      });
+    }
+  }
+
+  public static class UnsupportedArchDetectionTest {
+
+    @Test
+    public void testUnsupportedArch() throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(OS_ARCH_PROPERTY, "unsupported");
+        assertThrows(IllegalStateException.class, NativeLibLoader.Arch::detectArch);
+      });
+    }
+  }
+
+}

--- a/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/OsDetectionTest.java
+++ b/jvm-packages/xgboost4j/src/test/java/ml/dmlc/xgboost4j/java/OsDetectionTest.java
@@ -1,0 +1,85 @@
+/*
+ Copyright (c) 2014 by Contributors
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package ml.dmlc.xgboost4j.java;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Collection;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.restoreSystemProperties;
+import static java.util.Arrays.asList;
+import static junit.framework.TestCase.assertSame;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.WINDOWS;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.MACOS;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.LINUX;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.SOLARIS;
+import static ml.dmlc.xgboost4j.java.NativeLibLoader.OS.detectOS;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * Test cases for {@link NativeLibLoader.OS}.
+ */
+@RunWith(Enclosed.class)
+public class OsDetectionTest {
+
+  private static final String OS_NAME_PROPERTY = "os.name";
+
+  @RunWith(Parameterized.class)
+  public static class ParameterizedOSDetectionTest {
+
+    private final String osNameValue;
+    private final NativeLibLoader.OS expectedOS;
+
+    public ParameterizedOSDetectionTest(String osNameValue, NativeLibLoader.OS expectedOS) {
+      this.osNameValue = osNameValue;
+      this.expectedOS = expectedOS;
+    }
+
+    @Parameters
+    public static Collection<Object[]> data() {
+      return asList(new Object[][]{
+        {"windows", WINDOWS},
+        {"mac", MACOS},
+        {"darwin", MACOS},
+        {"linux", LINUX},
+        {"sunos", SOLARIS}
+      });
+    }
+
+    @Test
+    public void getOS() throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(OS_NAME_PROPERTY, osNameValue);
+        assertSame(detectOS(), expectedOS);
+      });
+    }
+  }
+
+  public static class UnsupportedOSDetectionTest {
+
+    @Test
+    public void testUnsupportedOs() throws Exception {
+      restoreSystemProperties(() -> {
+        System.setProperty(OS_NAME_PROPERTY, "unsupported");
+        assertThrows(IllegalStateException.class, NativeLibLoader.OS::detectOS);
+      });
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for detecting musl-based Linux operating systems, when the `NativeLibLoader` tries to determine the path of the XGBoost4j shared library to load.

The solution for detecting a musl-based Linux system is based on how the the [sqlite-jdbc](https://github.com/xerial/sqlite-jdbc) project does it [here](https://github.com/xerial/sqlite-jdbc/blob/ada2b147dc858ef557a995e2f4ef25f7c65fc6a7/src/main/java/org/sqlite/util/OSInfo.java#L115-L131): it lists the memory-mapped files of a Linux system and checks whether any name contains the string "musl". If that's the case, the OS is considered a musl-based Linux system.

The path of the shared library for a regular Linux-based system for x86_64 architecture is still `linux/x86_64/libxgboost4j.so`. For a musl-based system this would now be `linux-musl/x86_64/libxgboost4j.so`.

This even works for Arm-based versions, where the path would be `linux-musl/aarch64/libxgboost4j.so`.
